### PR TITLE
Add tests for existing handlers and document testing

### DIFF
--- a/docs/adding-flags.md
+++ b/docs/adding-flags.md
@@ -102,4 +102,14 @@ func initializeRoutes() {
 
 ## Adding Your Tests
 
-This section is coming soon.
+Finally, you'll want to add tests to make sure your flag is solvable in an expected way. Create a file `handlers.flagX_test.go` where `X` is your flag number. As an example "flag99" would look like `handlers.flag99_test.go`.
+
+Your test file should contain at least two function signatures. The primary function is your exported test handler function. This is what gets called when `go test` is run, and it should test your clue rendering. It also should handle all HTTP request recording, regardless of whether you need to make multiple requests in order to test clue rendering and success cases.
+
+The second function should test the success case for your flag. The function signature should vary, and should contain only the data necessary to test the expected flag matches the received flag.
+
+You will not have to set up a router for your tests. A router is prepared as `router` in existing tests for your use. Your tests will need to set up any recorders, however. 
+
+Refer to the test case for [flag0](../handlers.flag0_test.go) which performs a substring match against the page body to check for the existence of the flag. 
+
+In addition, several helper functions exist for enduring that core components of your clue pages render appropriately (such as the Header, Footer, etc). Other helpers such as status code and substring matches are available as well. Find those in [handlers_test.go](..handlers_test.go).

--- a/handlers.flag0_test.go
+++ b/handlers.flag0_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestFlag0Handler testes getFlag0()
+func TestFlag0Handler(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	req, _ := http.NewRequest("GET", "/flag0", nil)
+	router.ServeHTTP(w, req)
+
+	// test the status code
+	testStatusCode(t, w.Code, http.StatusOK)
+
+	// test the header, footer, and nav renders
+	testCommonTemplatesRender(t, w.Body.String())
+
+	// test the body of the index
+	testBodyContains(t, `<h1>The flag is in the source...</h1>`, w.Body.String())
+
+	testFlag0Success(t, w.Body.String())
+}
+
+// testFlag0Success does what's necessary for flag0 to succeed
+// and confirms that the received flag is as expected.
+func testFlag0Success(t *testing.T, body string) {
+	id := 0
+	f, err := getFlag(id)
+	if err != nil {
+		t.Error("The flag at the provided ID was not found: ", id)
+	}
+
+	testBodyContains(t, f.Flag, body)
+}

--- a/handlers.flag1_test.go
+++ b/handlers.flag1_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestFlag1Handler testes getFlag1()
+func TestFlag1Handler(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	req, _ := http.NewRequest("GET", "/flag1", nil)
+	router.ServeHTTP(w, req)
+
+	// test the status code
+	testStatusCode(t, w.Code, http.StatusOK)
+
+	// test the header, footer, and nav renders
+	testCommonTemplatesRender(t, w.Body.String())
+
+	// test the body of the index
+	testBodyContains(t, `<h1>The headers</h1`, w.Body.String())
+
+	testFlag1Success(t, w.Header())
+}
+
+// testFlag1Success does what's necessary for flag1 to succeed
+// and confirms that the received flag is as expected.
+func testFlag1Success(t *testing.T, headers http.Header) {
+	id := 1
+	header := "X-Yctf"
+	f, err := getFlag(id)
+	if err != nil {
+		t.Error("The flag at the provided ID was not found: ", id)
+	}
+
+	if f.Flag != headers[header][0] {
+		t.Errorf("Unable to find flag in expected response header %s.\n Got: %s\nWant %s",
+			header, headers[header][0], f.Flag)
+	}
+
+}

--- a/handlers.flag2_test.go
+++ b/handlers.flag2_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestFlag2Handler testes getFlag2()
+func TestFlag2Handler(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	req, _ := http.NewRequest("GET", "/flag2", nil)
+	router.ServeHTTP(w, req)
+
+	// test the status code
+	testStatusCode(t, w.Code, http.StatusOK)
+
+	// test the header, footer, and nav renders
+	testCommonTemplatesRender(t, w.Body.String())
+
+	// test the body of the index
+	testBodyContains(t, `<h1>Om nom 🍪</h1>`, w.Body.String())
+
+	testFlag2Success(t, w.Result().Cookies())
+}
+
+// testFlag2Success does what's necessary for flag2 to succeed
+// and confirms that the received flag is as expected.
+func testFlag2Success(t *testing.T, c []*http.Cookie) {
+	id := 2
+	cookieName := "flag2"
+	f, err := getFlag(id)
+	if err != nil {
+		t.Error("The flag at the provided ID was not found: ", id)
+	}
+
+	// the cookie when accessed via recorder is flag2=val
+	// so we need to split to test the value
+	fkv := strings.Split(c[0].String(), ";")[0]
+	cookieVal := strings.Split(fkv, "=")[1]
+
+	if f.Flag != cookieVal {
+		t.Errorf("Unable to find flag in expected cookie %s.\n Got: %s\nWant: %s",
+			cookieName, cookieVal, f.Flag)
+	}
+}

--- a/handlers.flag3_test.go
+++ b/handlers.flag3_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestFlag1Handler testes getFlag1()
+func TestFlag3Handler(t *testing.T) {
+	htmlw := httptest.NewRecorder()
+	jsonw := httptest.NewRecorder()
+
+	htmlreq, _ := http.NewRequest("GET", "/flag3", nil)
+	router.ServeHTTP(htmlw, htmlreq)
+
+	jsonreq, _ := http.NewRequest("GET", "/flag3", nil)
+	jsonreq.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(jsonw, jsonreq)
+
+	// test the status code
+	testStatusCode(t, htmlw.Code, http.StatusOK)
+
+	// test the header, footer, and nav renders
+	testCommonTemplatesRender(t, htmlw.Body.String())
+
+	// test the body of the index
+	testBodyContains(t, `<a href="https://json.org">This is not JSON</a>`, htmlw.Body.String())
+
+	testFlag3Success(t, jsonw.Body.String())
+}
+
+// testFlag3Success does what's necessary for flag3 to succeed
+// and confirms that the received flag is as expected.
+func testFlag3Success(t *testing.T, jsonbody string) {
+	id := 3
+	f, err := getFlag(id)
+	if err != nil {
+		t.Error("The flag at the provided ID was not found: ", id)
+	}
+
+	// the json response from the serve is quoted, we need to remove that to test.
+	jsonflag := strings.Trim(jsonbody, `"`)
+
+	if f.Flag != jsonflag {
+		t.Errorf("Unable to find flag in expected JSON payload.\n Got: %s\nWant %s",
+			jsonflag, f.Flag)
+	}
+}

--- a/handlers.flag4_test.go
+++ b/handlers.flag4_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestFlag4Handler testes getFlag4()
+func TestFlag4Handler(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	req, _ := http.NewRequest("GET", "/flag4", nil)
+	router.ServeHTTP(w, req)
+
+	// test the status code
+	testStatusCode(t, w.Code, http.StatusOK)
+
+	// test the header, footer, and nav renders
+	testCommonTemplatesRender(t, w.Body.String())
+
+	// test the body of the index
+	testBodyContains(t, `<p>You don't look like a bot`, w.Body.String())
+
+	req.Header.Set("User-Agent", "Wall-E Scraperbot")
+	router.ServeHTTP(w, req)
+
+	testFlag4Success(t, w.Body.String())
+}
+
+// testFlag4Success does what's necessary for flag4 to succeed
+// and confirms that the received flag is as expected.
+func testFlag4Success(t *testing.T, body string) {
+	id := 4
+	f, err := getFlag(id)
+	if err != nil {
+		t.Error("The flag at the provided ID was not found: ", id)
+	}
+
+	testBodyContains(t, f.Flag, body)
+}

--- a/handlers.flag5_test.go
+++ b/handlers.flag5_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestFlag5Handler testes getFlag5()
+func TestFlag5Handler(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	req, _ := http.NewRequest("GET", "/flag5", nil)
+	router.ServeHTTP(w, req)
+
+	// test the status code
+	testStatusCode(t, w.Code, http.StatusUnauthorized)
+
+	// test the header, footer, and nav renders
+	testCommonTemplatesRender(t, w.Body.String())
+
+	// test the body of the index
+	testBodyContains(t, `<a href="./">Only authorized users are allowed`, w.Body.String())
+
+	req.AddCookie(&http.Cookie{
+		Name:  "auth",
+		Value: "true",
+	})
+	router.ServeHTTP(w, req)
+
+	testFlag5Success(t, w.Body.String())
+}
+
+// testFlag5Success does what's necessary for flag5 to succeed
+// and confirms that the received flag is as expected.
+func testFlag5Success(t *testing.T, body string) {
+	id := 5
+	f, err := getFlag(id)
+	if err != nil {
+		t.Error("The flag at the provided ID was not found: ", id)
+	}
+
+	testBodyContains(t, f.Flag, body)
+}

--- a/handlers.flag6_test.go
+++ b/handlers.flag6_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestFlag6Handler testes getFlag6()
+func TestFlag6Handler(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	req, _ := http.NewRequest("GET", "/flag6", nil)
+	router.ServeHTTP(w, req)
+
+	// test the status code
+	testStatusCode(t, w.Code, http.StatusOK)
+
+	// test the header, footer, and nav renders
+	testCommonTemplatesRender(t, w.Body.String())
+
+	// test the body of the index
+	testBodyContains(t, `only IPs from '10.0.0.0/8' are allowed</p>`, w.Body.String())
+
+	req.Header.Set("x-forwarded-for", "10.0.0.1")
+	router.ServeHTTP(w, req)
+	testFlag6Success(t, w.Body.String())
+}
+
+// testFlag6Success does what's necessary for flag0 to succeed
+// and confirms that the received flag is as expected.
+func testFlag6Success(t *testing.T, body string) {
+	id := 6
+	f, err := getFlag(id)
+	if err != nil {
+		t.Error("The flag at the provided ID was not found: ", id)
+	}
+
+	testBodyContains(t, f.Flag, body)
+}

--- a/handlers.flag7_test.go
+++ b/handlers.flag7_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestFlag7Handler testes getFlag7()
+func TestFlag7Handler(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	req, _ := http.NewRequest("GET", "/flag7", nil)
+	router.ServeHTTP(w, req)
+
+	// test the status code
+	testStatusCode(t, w.Code, http.StatusBadRequest)
+
+	// test the header, footer, and nav renders
+	testCommonTemplatesRender(t, w.Body.String())
+
+	// test the body of the index
+	testBodyContains(t, `flag</code> and ask it nicely`, w.Body.String())
+
+	q := req.URL.Query()
+	q.Add("flag", "flag7")
+	q.Add("please", "true")
+	req.URL.RawQuery = q.Encode()
+	router.ServeHTTP(w, req)
+	testFlag7Success(t, w.Body.String())
+}
+
+// testFlag7Success does what's necessary for flag7 to succeed
+// and confirms that the received flag is as expected.
+func testFlag7Success(t *testing.T, body string) {
+	id := 7
+	f, err := getFlag(id)
+	if err != nil {
+		t.Error("The flag at the provided ID was not found: ", id)
+	}
+
+	testBodyContains(t, f.Flag, body)
+}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func init() {
+	router = setupRouter()
+}
+
+// TestIndexHandler tests showIndex()
+func TestIndexHandler(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	req, _ := http.NewRequest("GET", "/", nil)
+	router.ServeHTTP(w, req)
+
+	// test the status code
+	testStatusCode(t, w.Code, http.StatusOK)
+
+	// test the header, footer, and nav renders
+	testCommonTemplatesRender(t, w.Body.String())
+
+	// test the body of the index
+	testBodyContains(t, `<h1>Welcome to yCTF</h1>`, w.Body.String())
+}
+
+// TestValidateFlag tests validateFlag(), which is unimplemented at this point
+// this is is a scaffolded test for when it is implemented.
+func TestValidateFlag(t *testing.T) {
+	t.Log("Unimplemented!")
+}
+
+// testStatusCode confirms that the wanted status code matches that received.
+func testStatusCode(t *testing.T, want, got int) {
+	if want != got {
+		t.Errorf("The status code is incorrect.\n Got: %v\nWant %v\n", got, want)
+	}
+}
+
+// testBodyContains checks the body for a substring to confirm a template rendered.
+func testBodyContains(t *testing.T, want, got string) {
+	if !strings.Contains(got, want) {
+		t.Errorf(
+			"The page did not contain a substring expected from the rendered template.\n Got: %v\nWant: %v\n", got, want)
+	}
+}
+
+// testCommonTemplatesRender is an aggregate function checking that the
+// header, footer, and nav rendered.
+func testCommonTemplatesRender(t *testing.T, in string) {
+	testHeaderRenders(t, in)
+	testFooterRenders(t, in)
+	testNavRenders(t, in)
+}
+
+// testHeaderRenders checks if the header rendered by matching a string
+// expected in the header only.
+func testHeaderRenders(t *testing.T, in string) {
+	// test the header renders
+	testBodyContains(t, "<!doctype html>", in)
+}
+
+// testFooterRenders checks if the footer renedered by matching a string
+// expected in the footer only.
+func testFooterRenders(t *testing.T, in string) {
+	// test the footer renders
+	testBodyContains(t, "</html>", in)
+}
+
+// testNavRenders checks if the nav rendered by matching a string expected
+// in the footer only.
+func testNavRenders(t *testing.T, in string) {
+	// test the nav renders
+	testBodyContains(t, `<nav class="navbar navbar-default">`, in)
+}

--- a/main.go
+++ b/main.go
@@ -7,14 +7,15 @@ import (
 var router *gin.Engine
 
 func main() {
-
-	router = gin.Default()
-
-	router.LoadHTMLGlob("templates/*")
-
-	initializeRoutes()
-
+	router := setupRouter()
 	router.Run()
+}
+
+func setupRouter() *gin.Engine {
+	router = gin.Default()
+	router.LoadHTMLGlob("templates/*")
+	initializeRoutes()
+	return router
 }
 
 func render(c *gin.Context, httpStatus int, data gin.H, templateName string) {


### PR DESCRIPTION
Fixes #1 

Also included in this PR is a commit to modularize the setup steps of the router so that a router can be initialized with handlers during testing where `main.go` is not running. 

Also worth noting that flag8 is listed on the rendered index because it exists in flags.json, but the handler and template are not in place so no test was written.

There is one placeholder test for function `ValidateFlag`. The function is unimplemented from what I saw so the test indicates the same.

It's unclear how to test the models given that they have hard-coded references to a "file on disk", and, for the most part, accept no parameters. Thinking those need a refactor before the can be tested.

```(yctf) $ go test -v
[GIN-debug] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.

[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:	export GIN_MODE=release
 - using code:	gin.SetMode(gin.ReleaseMode)

[GIN-debug] Loaded HTML Templates (14): 
	- flag1.html
	- flag2.html
	- flag6.html
	- footer.html
	- flag4.html
	- 401.html
	- flag3.html
	- index.html
	- menu.html
	- 
	- flag0.html
	- flag5.html
	- flag7.html
	- header.html

[GIN-debug] GET    /                         --> github.com/tonyskapunk/yctf.showIndex (3 handlers)
[GIN-debug] GET    /flag0                    --> github.com/tonyskapunk/yctf.getFlag0 (3 handlers)
[GIN-debug] GET    /flag1                    --> github.com/tonyskapunk/yctf.getFlag1 (3 handlers)
[GIN-debug] GET    /flag2                    --> github.com/tonyskapunk/yctf.getFlag2 (3 handlers)
[GIN-debug] GET    /flag3                    --> github.com/tonyskapunk/yctf.getFlag3 (3 handlers)
[GIN-debug] GET    /flag4                    --> github.com/tonyskapunk/yctf.getFlag4 (3 handlers)
[GIN-debug] GET    /flag5                    --> github.com/tonyskapunk/yctf.getFlag5 (3 handlers)
[GIN-debug] GET    /flag6                    --> github.com/tonyskapunk/yctf.getFlag6 (3 handlers)
[GIN-debug] GET    /flag7                    --> github.com/tonyskapunk/yctf.getFlag7 (3 handlers)
=== RUN   TestFlag0Handler
[GIN] 2020/10/24 - 09:05:28 | 200 |    1.173018ms |                 | GET      "/flag0"
--- PASS: TestFlag0Handler (0.00s)
=== RUN   TestFlag1Handler
[GIN] 2020/10/24 - 09:05:28 | 200 |      853.04µs |                 | GET      "/flag1"
--- PASS: TestFlag1Handler (0.00s)
=== RUN   TestFlag2Handler
[GIN] 2020/10/24 - 09:05:28 | 200 |     803.996µs |                 | GET      "/flag2"
--- PASS: TestFlag2Handler (0.00s)
=== RUN   TestFlag3Handler
[GIN] 2020/10/24 - 09:05:28 | 200 |       968.5µs |                 | GET      "/flag3"
[GIN] 2020/10/24 - 09:05:28 | 200 |      70.426µs |                 | GET      "/flag3"
--- PASS: TestFlag3Handler (0.00s)
=== RUN   TestFlag4Handler
[GIN] 2020/10/24 - 09:05:28 | 200 |     809.617µs |                 | GET      "/flag4"
[GIN] 2020/10/24 - 09:05:28 | 200 |     832.804µs |                 | GET      "/flag4"
--- PASS: TestFlag4Handler (0.00s)
=== RUN   TestFlag5Handler
[GIN] 2020/10/24 - 09:05:28 | 401 |     776.402µs |                 | GET      "/flag5"
[GIN] 2020/10/24 - 09:05:28 | 200 |     740.468µs |                 | GET      "/flag5"
--- PASS: TestFlag5Handler (0.00s)
=== RUN   TestFlag6Handler
[GIN] 2020/10/24 - 09:05:28 | 200 |     765.237µs |                 | GET      "/flag6"
[GIN] 2020/10/24 - 09:05:28 | 200 |      801.21µs |        10.0.0.1 | GET      "/flag6"
--- PASS: TestFlag6Handler (0.00s)
=== RUN   TestFlag7Handler
[GIN] 2020/10/24 - 09:05:28 | 400 |     877.034µs |                 | GET      "/flag7"
[GIN] 2020/10/24 - 09:05:28 | 200 |     772.539µs |                 | GET      "/flag7?flag=flag7&please=true"
--- PASS: TestFlag7Handler (0.00s)
=== RUN   TestIndexHandler
[GIN] 2020/10/24 - 09:05:28 | 200 |    1.432994ms |                 | GET      "/"
--- PASS: TestIndexHandler (0.00s)
=== RUN   TestValidateFlag
--- PASS: TestValidateFlag (0.00s)
    handlers_test.go:34: Unimplemented!
PASS
ok  	github.com/tonyskapunk/yctf	0.037s```