### PR TITLE
Add an approach to generating flags packaged as a library

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -14,12 +14,15 @@ github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GO
 github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/flag/doc.go
+++ b/pkg/flag/doc.go
@@ -1,0 +1,4 @@
+// Package flag provides a factory approach to generating flags for the yctf
+// game. It generates flags based on a seed, and factory can then validate flags
+// were generated using its seed.
+package flag

--- a/pkg/flag/factory.go
+++ b/pkg/flag/factory.go
@@ -1,0 +1,57 @@
+package flag
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+)
+
+const (
+	prefix = "yctf"
+)
+
+// Factory represents the flag factory interface. It's what is needed
+// to generate a flag and validate flags have been generated through it.
+type Factory interface {
+	Seed() string
+	NewFlag(in []byte) *flag
+	Validate(f *Flag) bool
+}
+
+type factory struct {
+	seed      string
+	generated []string
+}
+
+// NewFactory returns a simple factory that helps generate flags.
+func NewFactory(seed string) *factory {
+	return &factory{
+		seed: seed,
+	}
+}
+
+// Seed returns the seed provided as input to the factory.
+func (f *factory) Seed() string {
+	return f.seed
+}
+
+// Validate checks a flag to see if the seed stored in the flag
+// matches the seed in the factory. It also regenerates the hash based on the
+// inputs stored in the flag to ensure the value matches based on the input
+func (f *factory) Validate(fl Flag) bool {
+	return fl.Seed() == f.Seed() && fl.Raw() == fmt.Sprintf("%x", sha256.Sum256(fl.Data()))
+}
+
+// NewFlag returns a flag containing a the input value, the seed stored in the factory,
+// and the calculated value of that flag. The calculated value of that flag is a
+// sha256 sum of the input concatenated with the seed.
+func (f *factory) NewFlag(in []byte) *flag {
+	data := bytes.Join([][]byte{in, []byte(f.seed)}, []byte{})
+	sum := sha256.Sum256(data)
+	return &flag{
+		input: in,
+		value: fmt.Sprintf("%x", sum),
+		seed:  f.seed,
+		data:  data,
+	}
+}

--- a/pkg/flag/flag.go
+++ b/pkg/flag/flag.go
@@ -1,0 +1,59 @@
+package flag
+
+import "strings"
+
+// Flag represents all of the necessary functions to accurately describe and use
+// a flag.
+type Flag interface {
+	Seed() string
+	Input() []byte
+	InputAsString() string
+	Data() []byte
+	DataAsString() string
+	String() string
+	Raw() string
+}
+
+type flag struct {
+	input []byte
+	value string
+	seed  string
+	data  []byte
+}
+
+// Seed returns the seed used to generate the flag.
+func (fl *flag) Seed() string {
+	return fl.seed
+}
+
+// Input returns the input used to generate the flag.
+func (fl *flag) Input() []byte {
+	return fl.input
+}
+
+// InputAsString returns the input used to generate the flag, but as a string
+func (fl *flag) InputAsString() string {
+	return string(fl.input)
+}
+
+// Data returns the concatenation of the input and the seed which is fed into the
+// hashing function as a byte slice.
+func (fl *flag) Data() []byte {
+	return fl.data
+}
+
+// DataAsString returns the concatenation of the input and the seed which is fed into the
+// hashing function as a a string.
+func (fl *flag) DataAsString() string {
+	return string(fl.data)
+}
+
+// String returns the flag's value as a string. This includes the yctf prefix and the hash.
+func (fl *flag) String() string {
+	return strings.Join([]string{prefix, fl.value}, "-")
+}
+
+// Raw returns the flag's hash as a string without the prefix.
+func (fl *flag) Raw() string {
+	return fl.value
+}


### PR DESCRIPTION
Here's an approach to generating flags in a programmatic way. This also allows for generating flags based on a seed. The sha256sum input is a concatenation of the input (such as flag name) and the seed (provided at factory instantiation).

Here's an example code using the library (the import path is mocked). 

```go
package main

import (
	"fmt"

	"github.com/komish/hackery-sha256sum/flag"
)

func main() {
	// generate a new factory
	fact := flag.NewFactory("123456")

	/// generate a flag from that factory
	f := fact.NewFlag([]byte("flag0"))

	// print out the relevant information for that flag
	fmt.Println(f.String()) // this gives us the flag with prefix
	fmt.Println(f.Raw())    // this gives us the sum itself

	// ask the factory to validate the flag it generated
	fmt.Println("flag is generated from factory one:", fact.Validate(f))

	// generate a second factory with a different seed
	fact2 := flag.NewFactory("")

	// ask the second factory to validate the flag the first factory generated
	fmt.Println("flag is generated from factory two:", fact2.Validate(f))
}
```

The output is as follows on my machine:

```
yctf-86753139b921b8ecd90306299546c8f7c630d52bb0f790a7354159879a9c428c
86753139b921b8ecd90306299546c8f7c630d52bb0f790a7354159879a9c428c
flag is generated from factory one: true
flag is generated from factory two: false
```

I don't think this quite addresses #3 and #4 but it might help along the way. The validation, for example, doesn't work exactly as #3 would need. Either way, it's a starting point!