### PR TITLE
Fix linting issues identified by golangci-lint

### DIFF
--- a/.github/workflows/go_lint.yml
+++ b/.github/workflows/go_lint.yml
@@ -12,18 +12,11 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.19
+        id: go
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.32
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
+        run: make lint

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+bin/
 
 # Test binary, built with `go test -c`
 *.test

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,68 +7,8 @@ run:
   timeout: 2m
 
 linters:
-  disable-all: true
-  enable:
-    - asciicheck
-    #- bodyclose
-    #- deadcode
-    #- depguard
-    #- dogsled
-    #- dupl
-    #- errcheck
-    #- errorlint
-    #- exhaustive
-    #- exhaustivestruct
-    #- exportloopref
-    #- funlen
-    #- gci
-    #- gochecknoglobals
-    #- gochecknoinits
-    #- gocognit
-    #- goconst
-    #- gocritic
-    #- gocyclo
-    #- godot
-    #- godox
-    #- goerr113
-    #- gofmt
-    #- gofumpt
-    #- goheader
-    #- goimports
-    #- golint
-    #- gomnd
-    #- gomodguard
-    #- goprintffuncname
-    #- gosec
-    #- gosimple
-    #- govet
-    #- ineffassign
-    #- interfacer
-    #- lll
-    #- maligned
-    #- misspell
-    #- nakedret
-    #- nestif
-    #- nlreturn
-    #- noctx
-    #- nolintlint
-    #- prealloc
-    #- rowserrcheck
-    #- scopelint
-    #- sqlclosecheck
-    #- staticcheck
-    #- structcheck
-    #- stylecheck
-    #- testpackage
-    #- tparallel
-    #- typecheck
-    #- unconvert
-    #- unparam
-    #- unused
-    #- varcheck
-    #- whitespace
-    #- wrapcheck
-    #- wsl
+  disable:
+    - unused # temporarily disabled until flag factory code is put to use or removed
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: lint
+lint: golangci-lint
+	$(GOLANGCI_LINT) run
+
+# install golangci-lint
+GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint 	# to this path
+GOLANGCI_LINT_VERSION ?= v1.50.0 				# at this version
+golangci-lint: $(GOLANGCI_LINT)
+$(GOLANGCI_LINT):
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION))
+
+# go-install-tool will 'go get' any package $2 and install it to $1.
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+define go-install-tool
+@[ -f $(1) ] || { \
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
+}
+endef

--- a/handlers.go
+++ b/handlers.go
@@ -3,6 +3,8 @@ package main
 import (
 	"net/http"
 
+	"log"
+
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-gonic/gin"
 )
@@ -23,7 +25,9 @@ func showIndex(c *gin.Context) {
 		session.Set("flags", len(flags))
 	}
 	if s == nil || f == nil {
-		session.Save()
+		err := session.Save()
+		// TODO: Identify proper path to take when a session save doesn't work
+		log.Println("WARN unable to save session:", err)
 	}
 
 	render(c, http.StatusOK, gin.H{

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"net/http"
 	"os"
 
@@ -18,7 +19,9 @@ var router *gin.Engine
 
 func main() {
 	router := setupRouter()
-	router.Run()
+	if err := router.Run(); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func setupRouter() *gin.Engine {

--- a/models.go
+++ b/models.go
@@ -3,8 +3,8 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 )
 
 type flag struct {
@@ -17,7 +17,7 @@ type flag struct {
 func getAllFlags() []flag {
 	var flags []flag
 
-	data, err := ioutil.ReadFile("./flags.json")
+	data, err := os.ReadFile("./flags.json")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The `golangci-lint` tool was added with most linters disabled. This PR:

- bumps the golangci-lint version to 1.49 in the github workflow
- adds a Makefile target that installs golangci-lint for developers to be able to download the exact version they need locally
- adds the output directory of ☝️ to the .gitignore so it's not committed
- enables all linters and fixes discovered issues (except for unused because the flags package is currently not leveraged). 

I opted not to squash these as I figured the code changes should be committed individually.

fixes #14 